### PR TITLE
詳細ページに「前へ」「次へ」リンクを追加する

### DIFF
--- a/app/Http/Controllers/QuestionController.php
+++ b/app/Http/Controllers/QuestionController.php
@@ -12,7 +12,7 @@ class QuestionController extends Controller
     public function index(): View
     {
         return view('question.index', [
-            'questions' => Question::latest()->paginate(20),
+            'questions' => Question::latest('id')->paginate(20),
         ]);
     }
 
@@ -35,6 +35,8 @@ class QuestionController extends Controller
     {
         return view('question.show', [
             'question' => $question,
+            'previous' => Question::after($question)->oldest('id')->first(),
+            'next' => Question::before($question)->latest('id')->first(),
         ]);
     }
 

--- a/app/Models/Question.php
+++ b/app/Models/Question.php
@@ -2,6 +2,7 @@
 
 namespace App\Models;
 
+use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 
@@ -13,4 +14,20 @@ class Question extends Model
         'body',
         'answer',
     ];
+
+    /**
+     *  Scope 指定された問題以前に作成
+     */
+    public function scopeBefore(Builder $query, self $currentQuestion): void
+    {
+        $query->where('id', '<', $currentQuestion->id);
+    }
+
+    /**
+     *  Scope 指定された問題以降に作成
+     */
+    public function scopeAfter(Builder $query, self $currentQuestion): void
+    {
+        $query->where('id', '>', $currentQuestion->id);
+    }
 }

--- a/resources/views/question/show.blade.php
+++ b/resources/views/question/show.blade.php
@@ -55,7 +55,46 @@
         </div>
     </div>
 
-    <div class="mt-3">
-        <a class="text-blue-600" href="{{route('questions.index')}}">問題一覧に戻る</a>
+    <div class="hidden sm:flex-1 sm:flex sm:items-center sm:justify-between">
+        <div class="mt-3">
+            <a class="text-blue-600" href="{{route('questions.index')}}">問題一覧に戻る</a>
+        </div>
+        <div>
+            <span class="relative z-0 inline-flex rtl:flex-row-reverse shadow-sm rounded-md">
+                {{-- Previous Page Link --}}
+                @if ($previous)
+                    <a href="{{ route('questions.show', ['question' => $previous->id]) }}" rel="prev"
+                       class="relative inline-flex items-center px-2 py-2 text-sm font-medium text-gray-500 bg-white border border-gray-300 rounded-l-md leading-5 hover:text-gray-400 focus:z-10 focus:outline-none focus:ring ring-gray-300 focus:border-blue-300 active:bg-gray-100 active:text-gray-500 transition ease-in-out duration-150 dark:bg-gray-800 dark:border-gray-600 dark:active:bg-gray-700 dark:focus:border-blue-800"
+                       aria-label="{{ __('pagination.previous') }}">
+                        前へ
+                    </a>
+                @else
+                    <span aria-disabled="true" aria-label="{{ __('pagination.previous') }}">
+                        <span
+                            class="relative inline-flex items-center px-2 py-2 text-sm font-medium text-gray-500 bg-white border border-gray-300 cursor-default rounded-l-md leading-5 dark:bg-gray-800 dark:border-gray-600"
+                            aria-hidden="true">
+                            前へ
+                        </span>
+                    </span>
+                @endif
+
+                {{-- Next Page Link --}}
+                @if ($next)
+                    <a href="{{ route('questions.show', ['question' => $next->id]) }}" rel="next"
+                       class="relative inline-flex items-center px-2 py-2 -ml-px text-sm font-medium text-gray-500 bg-white border border-gray-300 rounded-r-md leading-5 hover:text-gray-400 focus:z-10 focus:outline-none focus:ring ring-gray-300 focus:border-blue-300 active:bg-gray-100 active:text-gray-500 transition ease-in-out duration-150 dark:bg-gray-800 dark:border-gray-600 dark:active:bg-gray-700 dark:focus:border-blue-800"
+                       aria-label="{{ __('pagination.next') }}">
+                        次へ
+                    </a>
+                @else
+                    <span aria-disabled="true" aria-label="{{ __('pagination.next') }}">
+                        <span
+                            class="relative inline-flex items-center px-2 py-2 -ml-px text-sm font-medium text-gray-500 bg-white border border-gray-300 cursor-default rounded-r-md leading-5 dark:bg-gray-800 dark:border-gray-600"
+                            aria-hidden="true">
+                            次へ
+                        </span>
+                    </span>
+                @endif
+            </span>
+        </div>
     </div>
 </x-app-layout>

--- a/tests/Feature/Question/IndexTest.php
+++ b/tests/Feature/Question/IndexTest.php
@@ -32,16 +32,18 @@ test('クエリパラメータpageが数値以外の場合1ページ目の内容
         ->assertSee($question->body);
 });
 
-describe('ページネーションのテスト', function () {
-    function makeQuestionData(int $cnt)
-    {
-        for ($i = 0; $i < $cnt; $i++) {
-            Question::factory()->create();
-        }
-    }
+test('作成の新しい順に問題が表示される', function () {
+    $question1 = Question::factory()->create();
+    $question2 = Question::factory()->create();
 
+    $this->get('/questions')
+        ->assertOK()
+        ->assertSeeInOrder([$question2->body, $question1->body]);
+});
+
+describe('ページネーションのテスト', function () {
     test('登録されている問題が20件以下の場合ページネーションが表示されない', function () {
-        makeQuestionData(20);
+        Question::factory()->count(20)->create();
 
         $this->get('/questions')
             ->assertOK()
@@ -52,7 +54,7 @@ describe('ページネーションのテスト', function () {
     });
 
     test('登録されている問題が21件以上の場合ページネーションが表示される', function () {
-        makeQuestionData(21);
+        Question::factory()->count(21)->create();
 
         $this->get('/questions')
             ->assertOK()
@@ -63,7 +65,7 @@ describe('ページネーションのテスト', function () {
     });
 
     test('2ページ目以降にいる場合前のページへのリンクが表示される', function () {
-        makeQuestionData(21);
+        Question::factory()->count(21)->create();
 
         $this->get('/questions?page=2')
             ->assertOK()

--- a/tests/Feature/Question/ShowTest.php
+++ b/tests/Feature/Question/ShowTest.php
@@ -20,3 +20,35 @@ test('idが存在しない場合、404を返す', function () {
     $this->get("/questions/{$nonExistingId}")
         ->assertNotFound();
 });
+
+describe('「前へ」「次へ」リンクのテスト', function () {
+    test('表示中の問題より新しい問題がある時、「前へ」リンクが有効になる', function () {
+        $newQuestion = Question::factory()->create();
+        $this->get("/questions/{$this->question->id}")
+            ->assertOk()
+            ->assertSee('前へ')
+            ->assertSee(route('questions.show', ['question' => $newQuestion->id]));
+    });
+
+    test('表示中の問題より新しい問題がない時、「前へ」リンクが無効になる', function () {
+        $this->get("/questions/{$this->question->id}")
+            ->assertOk()
+            ->assertSee('前へ')
+            ->assertSee('<span aria-disabled="true" aria-label="pagination.previous">', false);
+    });
+
+    test('表示中の問題より古い問題がある時、「次へ」リンクが有効になる', function () {
+        $newQuestion = Question::factory()->create();
+        $this->get("/questions/$newQuestion->id")
+            ->assertOk()
+            ->assertSee('次へ')
+            ->assertSee(route('questions.show', ['question' => $this->question->id]));
+    });
+
+    test('表示中の問題より古い問題がない時、「次へ」リンクが無効になる', function () {
+        $this->get("/questions/{$this->question->id}")
+            ->assertOk()
+            ->assertSee('次')
+            ->assertSee('<span aria-disabled="true" aria-label="pagination.next">', false);
+    });
+});


### PR DESCRIPTION
以下の件、実装しました！
[詳細ページに次の問題へのリンクを追加する](https://github.com/maru0914/question-maker/issues/4)
確認をお願いします🙇‍♂️


