### PR TITLE
画像アップロードキャンセル時にプレビューもキャンセルされるように修正

### DIFF
--- a/resources/views/components/input-file.blade.php
+++ b/resources/views/components/input-file.blade.php
@@ -26,15 +26,15 @@
 </script>
 <div x-data="imageViewer('{{ $src }}')">
     <template x-if="imageUrl">
-            <img :src="imageUrl"
-                 class="object-cover rounded border border-gray-200 max-h-48"
-                 alt="{{ $alt }}"
-            >
+        <img :src="imageUrl"
+             class="object-cover rounded border border-gray-200 max-h-48"
+             alt="{{ $alt }}"
+        >
     </template>
     <template x-if="!imageUrl">
         <div
-                class="border rounded border-gray-200 bg-gray-100"
-                style="width: 100px; height: 100px;"
+            class="border rounded border-gray-200 bg-gray-100"
+            style="width: 100px; height: 100px;"
         ></div>
     </template>
 


### PR DESCRIPTION
## 対応Issue
#19 

## 対応内容

ファイルアップロード時にキャンセルしてもプレビュー表示が残ってしまう問題を修正

- 問題集新規作成時
  - キャンセル時は画像非表示に
- 問題集編集時
  - キャンセル時は元々の画像を表示