### PR TITLE
questionsテーブルにbook_idとdefault_orderをカラム追加

### DIFF
--- a/app/Http/Controllers/QuestionController.php
+++ b/app/Http/Controllers/QuestionController.php
@@ -2,6 +2,7 @@
 
 namespace App\Http\Controllers;
 
+use App\Models\Book;
 use App\Models\Question;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
@@ -28,7 +29,14 @@ class QuestionController extends Controller
             'answer' => 'required',
         ]);
 
-        Question::create([...$data, 'user_id' => auth()->id()]);
+        $parentBook = Book::first() ?? Book::factory()->create(); // TODO: bookをユーザーが指定するようにする
+
+        Question::create([
+            ...$data,
+            'user_id' => auth()->id(),
+            'book_id' => $parentBook->id,
+            'default_order' => ($parentBook->questions->max('default_order') ?? 0) + 1,
+        ]);
 
         return redirect()->route('questions.index');
     }

--- a/app/Models/Book.php
+++ b/app/Models/Book.php
@@ -5,6 +5,7 @@ namespace App\Models;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\HasMany;
 
 class Book extends Model
 {
@@ -20,5 +21,10 @@ class Book extends Model
     public function user(): BelongsTo
     {
         return $this->belongsTo(User::class);
+    }
+
+    public function questions(): HasMany
+    {
+        return $this->hasMany(Question::class, 'book_id');
     }
 }

--- a/app/Models/Question.php
+++ b/app/Models/Question.php
@@ -13,9 +13,16 @@ class Question extends Model
 
     protected $fillable = [
         'user_id',
+        'book_id',
         'body',
         'answer',
+        'default_order',
     ];
+
+    public function book(): BelongsTo
+    {
+        return $this->belongsTo(Book::class);
+    }
 
     public function user(): BelongsTo
     {

--- a/database/factories/QuestionFactory.php
+++ b/database/factories/QuestionFactory.php
@@ -2,6 +2,7 @@
 
 namespace Database\Factories;
 
+use App\Models\Book;
 use App\Models\User;
 use Illuminate\Database\Eloquent\Factories\Factory;
 
@@ -19,8 +20,10 @@ class QuestionFactory extends Factory
     {
         return [
             'user_id' => User::factory(),
+            'book_id' => Book::factory(),
             'body' => fake()->text(),
             'answer' => fake()->text(),
+            'default_order' => 1,
         ];
     }
 }

--- a/database/migrations/2024_05_04_044112_add_columns_to_questions_table.php
+++ b/database/migrations/2024_05_04_044112_add_columns_to_questions_table.php
@@ -1,0 +1,46 @@
+<?php
+
+use App\Models\Book;
+use App\Models\Question;
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        $tmpBookId = 1;
+
+        // 既存レコード対応のため、デフォルト値を設定
+        Schema::table('questions', function (Blueprint $table) use ($tmpBookId) {
+            $table->foreignIdFor(Book::class)->after('user_id')->default($tmpBookId)->constrained();
+            $table->unsignedInteger('default_order')->after('book_id')->default(0);
+        });
+
+        // デフォルト値設定を解除
+        Schema::table('questions', function (Blueprint $table) {
+            $table->foreignIdFor(Book::class)->default(null)->change();
+            $table->unsignedInteger('default_order')->default(null)->change();
+        });
+
+        // 既存レコードについてdefault_orderを連番に変更してからユニーク制約を追加
+        Schema::table('questions', function (Blueprint $table) use ($tmpBookId) {
+            $questions = Question::where('book_id', $tmpBookId)->get();
+            foreach ($questions as $idx => $question) {
+                $question->default_order = $idx + 1;
+                $question->save();
+            }
+
+            $table->unique(['book_id', 'default_order']);
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('questions', function (Blueprint $table) {
+            $table->dropUnique(['book_id', 'default_order']);
+            $table->dropColumn(['book_id', 'default_order']);
+        });
+    }
+};


### PR DESCRIPTION
## 対応Issue
#25 

## 対応内容
SQLはテーブル作成時のみ外部キーが設定できるため、book_idに外部キーは付与できない。
MySQLでの実行時は付与されるようにマイグレーションには外部キー付与の記述を残しています。



